### PR TITLE
Use stable instead of nightly for static

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,14 +4,12 @@ environment:
   matrix:
     - TARGET: x86_64-pc-windows-msvc
       RUSTFLAGS: -Ctarget-feature=+crt-static
-      RUST: nightly
       VCPKG_DEFAULT_TRIPLET: x64-windows-static
     - TARGET: x86_64-pc-windows-msvc
       VCPKG_DEFAULT_TRIPLET: x64-windows
       VCPKGRS_DYNAMIC: 1
     - TARGET: i686-pc-windows-msvc
       RUSTFLAGS: -Ctarget-feature=+crt-static
-      RUST: nightly
       VCPKG_DEFAULT_TRIPLET: x86-windows-static
     - TARGET: i686-pc-windows-msvc
       VCPKG_DEFAULT_TRIPLET: x86-windows

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ win64_static:
   variables:
     TARGET: x86_64-pc-windows-msvc
     RUSTFLAGS: -Ctarget-feature=+crt-static
-    RUST: nightly
+    RUST: stable
     VCPKG_DEFAULT_TRIPLET: x64-windows-static
 
 win32_dynamic:
@@ -59,7 +59,7 @@ win32_static:
   variables:
     TARGET: i686-pc-windows-msvc
     RUSTFLAGS: -Ctarget-feature=+crt-static
-    RUST: nightly
+    RUST: stable
     VCPKG_DEFAULT_TRIPLET: x86-windows-static
     
 variables:


### PR DESCRIPTION
The flag `-Ctarget-feature=+crt-static` is now in Rust stable, so nightly is no longer needed.