### PR TITLE
Add a new option to Config to force a specific vcpkg root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -139,10 +139,10 @@ dependencies = [
 
 [[package]]
 name = "vcpkg_cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.7",
+ "vcpkg 0.2.8",
 ]
 
 [[package]]

--- a/vcpkg/Cargo.toml
+++ b/vcpkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vcpkg"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["Jim McGrath <jimmc2@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/mcgoo/vcpkg-rs"

--- a/vcpkg_cli/Cargo.toml
+++ b/vcpkg_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vcpkg_cli"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Jim McGrath <jimmc2@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/mcgoo/vcpkg-rs"
@@ -16,5 +16,5 @@ travis-ci = { repository = "mcgoo/vcpkg-rs", branch = "master" }
 appveyor = { repository = "mcgoo/vcpkg-rs", branch = "master", service="github" }
 
 [dependencies]
-vcpkg = { version = "0.2.6", path = "../vcpkg" }
+vcpkg = { version = "0.2.8", path = "../vcpkg" }
 clap = "2.31"

--- a/vcpkg_cli/src/main.rs
+++ b/vcpkg_cli/src/main.rs
@@ -103,6 +103,12 @@ fn main() {
                         println!("  {}", line.display());
                     }
                 }
+                if !lib.found_names.is_empty() {
+                    println!("Libraries linking names:");
+                    for line in &lib.found_names {
+                        println!("  {}", line);
+                    }
+                }
             }
             Err(err) => {
                 println!("Failed:  {}", err);


### PR DESCRIPTION
Also make Library keep a list of libraries short names to be easily
accessible.