### PR TITLE
Stage a crates-io index that doesn't have rand 0.8.0

### DIFF
--- a/.github/workflows/rust-1.10.yml
+++ b/.github/workflows/rust-1.10.yml
@@ -12,6 +12,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Work around incompatible crates.io
+        shell: bash
+        # Point cargo at a rewound copy of crates.io that is still understood at 1.10.0.
+        run: |
+          set -e
+          mkdir -p .cargo
+          cat <<EOF > .cargo/config
+          [sources.crates-io]
+          registry = "file://$(pwd)/../crates-io-rewound"
+          EOF
+          cd ..
+          git clone https://github.com/rust-lang/crates.io-index.git crates-io-rewound
+          cd crates-io-rewound
+          # Reset to a point where rand 0.8.0 didn't exist in index.
+          git reset --hard 46a429eac9f
       - name: Set default Rust
         run: rustup default 1.10.0
       - name: Run build

--- a/.github/workflows/rust-1.10.yml
+++ b/.github/workflows/rust-1.10.yml
@@ -16,7 +16,7 @@ jobs:
         shell: bash
         # Point cargo at a rewound copy of crates.io that is still understood at 1.10.0.
         run: |
-          set -e
+          set -ex
           mkdir -p .cargo
           cat <<EOF > .cargo/config
           [sources.crates-io]
@@ -27,6 +27,10 @@ jobs:
           cd crates-io-rewound
           # Reset to a point where rand 0.8.0 didn't exist in index.
           git reset --hard 46a429eac9f
+          # Prime the index registry using current cargo
+          cargo build --manifest-path vcpkg/Cargo.toml --verbose
+          # Clean up so rust 1.10.0 does its build.
+          cargo clean
       - name: Set default Rust
         run: rustup default 1.10.0
       - name: Run build

--- a/.github/workflows/rust-1.10.yml
+++ b/.github/workflows/rust-1.10.yml
@@ -22,12 +22,13 @@ jobs:
           [sources.crates-io]
           registry = "file://$(pwd)/../crates-io-rewound"
           EOF
-          cd ..
+          pushd ..
           git clone https://github.com/rust-lang/crates.io-index.git crates-io-rewound
           cd crates-io-rewound
           # Reset to a point where rand 0.8.0 didn't exist in index.
           git reset --hard 46a429eac9f
           # Prime the index registry using current cargo
+          popd
           cargo build --manifest-path vcpkg/Cargo.toml --verbose
           # Clean up so rust 1.10.0 does its build.
           cargo clean

--- a/.github/workflows/rust-1.12.yml
+++ b/.github/workflows/rust-1.12.yml
@@ -20,20 +20,22 @@ jobs:
         # from 1.12.0 and beyond.
         run: |
           set -ex
+          # Remove the Cargo.lock file, the checked in version isn't understood
+          # at 1.12.0.
+          popd
+          rm Cargo.lock
+          # Tell cargo to use a different copy of crates.io.
           mkdir -p .cargo
           cat <<EOF > .cargo/config
           [sources.crates-io]
           registry = "file://$(pwd)/../crates-io-rewound"
           EOF
-          pushd ..
+          # create copy of crates.io, reset back to when rand 0.8.0 didn't
+          # exist in index.
+          cd ..
           git clone https://github.com/rust-lang/crates.io-index.git crates-io-rewound
           cd crates-io-rewound
-          # Reset to a point where rand 0.8.0 didn't exist in index.
           git reset --hard 46a429eac9f
-          # Remove the Cargo.lock file, the checked in version isn't understood
-          # at 1.12.0.
-          popd
-          rm Cargo.lock
       - name: Set default Rust
         run: rustup default 1.12.0
       - name: Run build

--- a/.github/workflows/rust-1.12.yml
+++ b/.github/workflows/rust-1.12.yml
@@ -35,8 +35,10 @@ jobs:
           cargo build --manifest-path vcpkg/Cargo.toml --verbose
           # Clean up so rust 1.12.0 does its build.
           cargo clean
-          # Revert changes made to the Cargo.lock file as they won't be understood by the older version of cargo.
-          git checkout Cargo.lock
+          # Remove the Cargo.lock file as a it won't be understood by the older
+          # version of cargo, and the checked in version also isn't understood
+          # at 1.12.0.
+          rm Cargo.lock
       - name: Set default Rust
         run: rustup default 1.12.0
       - name: Run build

--- a/.github/workflows/rust-1.12.yml
+++ b/.github/workflows/rust-1.12.yml
@@ -26,7 +26,7 @@ jobs:
           # Tell cargo to use a different copy of crates.io.
           mkdir -p .cargo
           cat <<EOF > .cargo/config
-          [sources.crates-io]
+          [source.crates-io]
           registry = "file://$(pwd)/../crates-io-rewound"
           EOF
           cat .cargo/config

--- a/.github/workflows/rust-1.12.yml
+++ b/.github/workflows/rust-1.12.yml
@@ -22,7 +22,6 @@ jobs:
           set -ex
           # Remove the Cargo.lock file, the checked in version isn't understood
           # at 1.12.0.
-          popd
           rm Cargo.lock
           # Tell cargo to use a different copy of crates.io.
           mkdir -p .cargo

--- a/.github/workflows/rust-1.12.yml
+++ b/.github/workflows/rust-1.12.yml
@@ -14,10 +14,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Work around incompatible crates.io
         shell: bash
-        # Point cargo at a rewound copy of crates.io that is still understood
-        # at 1.10.0.
-        # Unfortunately, pointing at a registry like this is only supported
-        # from 1.12.0 and beyond.
+        # Point cargo at a rewound copy of crates.io that would be understood
+        # at 1.10.0.  Unfortunately, pointing at a registry like this is only
+        # supported from 1.12.0 and beyond.
         run: |
           set -ex
           # Remove the Cargo.lock file, the checked in version isn't understood

--- a/.github/workflows/rust-1.12.yml
+++ b/.github/workflows/rust-1.12.yml
@@ -30,12 +30,15 @@ jobs:
           [sources.crates-io]
           registry = "file://$(pwd)/../crates-io-rewound"
           EOF
+          cat .cargo/config
           # create copy of crates.io, reset back to when rand 0.8.0 didn't
           # exist in index.
           cd ..
           git clone https://github.com/rust-lang/crates.io-index.git crates-io-rewound
           cd crates-io-rewound
           git reset --hard 46a429eac9f
+          # Force the cargo registry to get rebuilt
+          rm -r ~/.cargo/registry/
       - name: Set default Rust
         run: rustup default 1.12.0
       - name: Run build

--- a/.github/workflows/rust-1.12.yml
+++ b/.github/workflows/rust-1.12.yml
@@ -32,6 +32,7 @@ jobs:
           git reset --hard 46a429eac9f
           # Remove the Cargo.lock file, the checked in version isn't understood
           # at 1.12.0.
+          popd
           rm Cargo.lock
       - name: Set default Rust
         run: rustup default 1.12.0

--- a/.github/workflows/rust-1.12.yml
+++ b/.github/workflows/rust-1.12.yml
@@ -1,4 +1,4 @@
-name: Rust 1.10 compile test
+name: Rust 1.12 compile test
 
 on:
   push:
@@ -14,7 +14,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Work around incompatible crates.io
         shell: bash
-        # Point cargo at a rewound copy of crates.io that is still understood at 1.10.0.
+        # Point cargo at a rewound copy of crates.io that is still understood
+        # at 1.10.0.
+        # Unfortunately, pointing at a registry like this is only supported
+        # from 1.12.0 and beyond.
         run: |
           set -ex
           mkdir -p .cargo
@@ -30,10 +33,10 @@ jobs:
           # Prime the index registry using current cargo
           popd
           cargo build --manifest-path vcpkg/Cargo.toml --verbose
-          # Clean up so rust 1.10.0 does its build.
+          # Clean up so rust 1.12.0 does its build.
           cargo clean
       - name: Set default Rust
-        run: rustup default 1.10.0
+        run: rustup default 1.12.0
       - name: Run build
         run: cargo build --manifest-path vcpkg/Cargo.toml --verbose
       # tests can't be run because they use ONCE which needs a newer compiler

--- a/.github/workflows/rust-1.12.yml
+++ b/.github/workflows/rust-1.12.yml
@@ -30,13 +30,7 @@ jobs:
           cd crates-io-rewound
           # Reset to a point where rand 0.8.0 didn't exist in index.
           git reset --hard 46a429eac9f
-          # Prime the index registry using current cargo
-          popd
-          cargo build --manifest-path vcpkg/Cargo.toml --verbose
-          # Clean up so rust 1.12.0 does its build.
-          cargo clean
-          # Remove the Cargo.lock file as a it won't be understood by the older
-          # version of cargo, and the checked in version also isn't understood
+          # Remove the Cargo.lock file, the checked in version isn't understood
           # at 1.12.0.
           rm Cargo.lock
       - name: Set default Rust

--- a/.github/workflows/rust-1.12.yml
+++ b/.github/workflows/rust-1.12.yml
@@ -36,8 +36,6 @@ jobs:
           git clone https://github.com/rust-lang/crates.io-index.git crates-io-rewound
           cd crates-io-rewound
           git reset --hard 46a429eac9f
-          # Force the cargo registry to get rebuilt
-          rm -r ~/.cargo/registry/
       - name: Set default Rust
         run: rustup default 1.12.0
       - name: Run build

--- a/.github/workflows/rust-1.12.yml
+++ b/.github/workflows/rust-1.12.yml
@@ -35,6 +35,8 @@ jobs:
           cargo build --manifest-path vcpkg/Cargo.toml --verbose
           # Clean up so rust 1.12.0 does its build.
           cargo clean
+          # Revert changes made to the Cargo.lock file as they won't be understood by the older version of cargo.
+          git checkout Cargo.lock
       - name: Set default Rust
         run: rustup default 1.12.0
       - name: Run build

--- a/notes.md
+++ b/notes.md
@@ -64,7 +64,7 @@
 
 - add a changelog for vcpkg_cli
 
-- make the breaking change of dropping Rust 1.10 compatibility when updating to 0.3
+- make the breaking change of dropping Rust 1.10 (actually 1.12) compatibility when updating to 0.3
 
 - vcpkg_cli should say if there are other versions of the ports available that do not match what is being looked for
 

--- a/vcpkg/src/lib.rs
+++ b/vcpkg/src/lib.rs
@@ -86,9 +86,11 @@
 //!         cargo:rustc-link-lib=static=mysqlclient
 //! ```
 
-// The CI will test vcpkg-rs on 1.10 because at this point rust-openssl's
-// openssl-sys is backward compatible that far. (Actually, the oldest release
-// crate openssl version 0.10 seems to build against is now Rust 1.24.1?)
+// The CI will test vcpkg-rs on 1.12 because that is how far back vcpkg-rs 0.2 tries to be
+// compatible (was actually 1.10 see #29).  This was originally based on how far back
+// rust-openssl's openssl-sys was backward compatible when this crate originally released.
+//
+// This will likely get bumped by the next major release.
 #![allow(deprecated)]
 #![allow(warnings)]
 


### PR DESCRIPTION
This PR tries to stage a crates-io mirror in the rust 1.10 test where the index is rewound to a point where rand 0.8.0 doesn't exist, as these entries confuse the old index resolution handling in 1.10.

Closes #28 