### PR TITLE
Bootstrapping for systest and tests

### DIFF
--- a/setup_vcp.sh
+++ b/setup_vcp.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# This script can be sourced to ensure VCPKG_ROOT points at a bootstrapped vcpkg repository.
+# It will also modify the environment (if sourced) to reflect any overrides in
+# vcpkg triplet used neccesary to match the semantics of vcpkg-rs.
+
+if [ "$VCPKG_ROOT" == "" ]; then
+  echo "VCPKG_ROOT must be set."
+  exit 1
+fi
+
+# Bootstrap ./vcp if it doesn't already exist.
+if [ ! -d "$VCPKG_ROOT" ]; then
+  echo "Bootstrapping ./vcp for systest"
+  pushd ..
+  git clone https://github.com/microsoft/vcpkg.git vcp
+  cd vcp
+  if [ "$OS" == "Windows_NT" ]; then
+    ./bootstrap-vcpkg.bat
+  else
+    ./bootstrap-vcpkg.sh
+  fi
+
+  popd
+fi
+
+# Override triplet used if we are on Windows, as the default there is 32bit
+# dynamic, whereas on 64 bit vcpkg-rs will prefer static with dynamic CRT
+# linking.
+if [ "$OS" == "Windows_NT" -a "$PROCESSOR_ARCHITECTURE" == "AMD64" ] ; then
+  export VCPKG_DEFAULT_TRIPLET=x64-windows-static-md
+fi

--- a/systest/run.sh
+++ b/systest/run.sh
@@ -2,9 +2,11 @@
 set -ex
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $SCRIPTDIR
+cd "$SCRIPTDIR"
 
-export VCPKG_ROOT=$SCRIPTDIR/../vcp
+export VCPKG_ROOT="$SCRIPTDIR/../vcp"
+
+source ../setup_vcp.sh
 
 $VCPKG_ROOT/vcpkg install curl zeromq openssl
 cargo run

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6,6 +6,8 @@ cd $SCRIPTDIR
 
 export VCPKG_ROOT=$SCRIPTDIR/../vcp
 
+source ../setup_vcp.sh
+
 for port in harfbuzz ; do
     # check that the port fails before it is installed
     $VCPKG_ROOT/vcpkg remove $port  || true


### PR DESCRIPTION
Augment `run.sh` in each directory with the ability to self bootstrap
the required vcpkg tree.

As well, override the triplet used when invoking the vcpkg tool on 64bit
Windows to match vcpkg-rs's triplet behavior.

Tested on Windows and Linux.