### PR TITLE
Manifest mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ Cargo.lock
 target/
 .vscode/
 vcp/
+
+.DS_Store
+
+.idea/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,14 +390,16 @@ fn find_vcpkg_target(cfg: &Config, target_triplet: &TargetTriplet) -> Result<Vcp
     let vcpkg_root = try!(find_vcpkg_root(&cfg));
     try!(validate_vcpkg_root(&vcpkg_root));
 
-    let mut base = if env::var_os("VCPKGRS_MANIFEST_MODE").is_none() {
-        let mut base = vcpkg_root.clone();
-        base.join("installed")
+    let cargo_base_path =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("we use cargo, this exists"));
+    let is_manifest_mode = env::var_os("VCPKGRS_IGNORE_MANIFEST_MODE").is_none()
+        && Path::exists(cargo_base_path.join("vcpkg.json").as_path());
+
+    if is_manifest_mode {
+        vcpkg_root.join("installed")
     } else {
-        let mut base =
-            PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("we use cargo, this exists"));
-        base.join("vcpkg_installed")
-    };
+        cargo_base_path.join("vcpkg_installed")
+    }
 
     let status_path = base.join("vcpkg");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,8 +390,15 @@ fn find_vcpkg_target(cfg: &Config, target_triplet: &TargetTriplet) -> Result<Vcp
     let vcpkg_root = try!(find_vcpkg_root(&cfg));
     try!(validate_vcpkg_root(&vcpkg_root));
 
-    let mut base = vcpkg_root.clone();
-    base.push("installed");
+    let mut base = if env::var_os("VCPKGRS_MANIFEST_MODE").is_none() {
+        let mut base = vcpkg_root.clone();
+        base.join("installed")
+    } else {
+        let mut base =
+            PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("we use cargo, this exists"));
+        base.join("vcpkg_installed")
+    };
+
     let status_path = base.join("vcpkg");
 
     base.push(&target_triplet.triplet);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,11 +395,11 @@ fn find_vcpkg_target(cfg: &Config, target_triplet: &TargetTriplet) -> Result<Vcp
     let is_manifest_mode = env::var_os("VCPKGRS_IGNORE_MANIFEST_MODE").is_none()
         && Path::exists(cargo_base_path.join("vcpkg.json").as_path());
 
-    if is_manifest_mode {
+    let mut base = if !is_manifest_mode {
         vcpkg_root.join("installed")
     } else {
         cargo_base_path.join("vcpkg_installed")
-    }
+    };
 
     let status_path = base.join("vcpkg");
 


### PR DESCRIPTION
This PR adds support for the manifest mode of vcpkg as discussed in issue #41.

By default it will be checked if a `vcpkg.json` file exists. If the user does not explicitly state that they don't want to use manifest mode by settings `VCPKGRS_IGNORE_MANIFEST_MODE` `vcpkg-rs` will check for dependencies in `$CARGO_MANIFEST_DIR/vcpkg_installed`.