### PR TITLE
Adding .DS_Store and .idea/ to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ Cargo.lock
 target/
 .vscode/
 vcp/
+.idea/
+.DS_Store


### PR DESCRIPTION
.DS_Store is a macOS specific file that doesn't need to be tracked and the .idea/ folder is specific to Jetbrains IDEs similar to .vscode/