### PR TITLE
Add support for mingw (-pc-windows-gnu) targets

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -117,5 +117,5 @@ jobs:
           ${VCPKG_ROOT}/vcpkg.exe install curl zeromq openssl
           cargo build --target ${{ matrix.config.target }} --all
           cargo test --target ${{ matrix.config.target }} --all
-          cargo run --target ${{ matrix.config.target }} --manifest-path vcpkg_cli/Cargo.toml -- probe curl
+          cargo run --target ${{ matrix.config.target }} --manifest-path vcpkg_cli/Cargo.toml -- --target ${{ matrix.config.target }} probe curl
           cargo run --target ${{ matrix.config.target }} --manifest-path systest/Cargo.toml

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,6 +40,24 @@ jobs:
               VCPKG_DEFAULT_TRIPLET: "x86-windows",
               VCPKGRS_DYNAMIC: 1,
             }
+          - {
+              target: "x86_64-pc-windows-gnu",
+              VCPKG_DEFAULT_TRIPLET: "x64-mingw-static",
+            }
+          - {
+              target: "x86_64-pc-windows-gnu",
+              VCPKG_DEFAULT_TRIPLET: "x64-mingw-dynamic",
+              VCPKGRS_DYNAMIC: 1,
+            }
+          - {
+              target: "i686-pc-windows-gnu",
+              VCPKG_DEFAULT_TRIPLET: "x86-mingw-static",
+            }
+          - {
+              target: "i686-pc-windows-gnu",
+              VCPKG_DEFAULT_TRIPLET: "x86-mingw-dynamic",
+              VCPKGRS_DYNAMIC: 1,
+            }
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,15 +49,16 @@ jobs:
               VCPKG_DEFAULT_TRIPLET: "x64-mingw-dynamic",
               VCPKGRS_DYNAMIC: 1,
             }
-          - {
-              target: "i686-pc-windows-gnu",
-              VCPKG_DEFAULT_TRIPLET: "x86-mingw-static",
-            }
-          - {
-              target: "i686-pc-windows-gnu",
-              VCPKG_DEFAULT_TRIPLET: "x86-mingw-dynamic",
-              VCPKGRS_DYNAMIC: 1,
-            }
+          # GitHub Actions doesn't have an i686 Mingw compiler.
+          # - {
+          #     target: "i686-pc-windows-gnu",
+          #     VCPKG_DEFAULT_TRIPLET: "x86-mingw-static",
+          #   }
+          # - {
+          #     target: "i686-pc-windows-gnu",
+          #     VCPKG_DEFAULT_TRIPLET: "x86-mingw-dynamic",
+          #     VCPKGRS_DYNAMIC: 1,
+          #   }
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1499,16 +1499,16 @@ mod tests {
     fn do_nothing_for_unsupported_target() {
         let _g = LOCK.lock();
         env::set_var("VCPKG_ROOT", "/");
-        env::set_var("TARGET", "x86_64-pc-windows-gnu");
+        env::set_var("TARGET", "x86_64-pc-windows-invalid");
         assert!(match ::probe_package("foo") {
             Err(Error::NotMSVC) => true,
             _ => false,
         });
 
-        env::set_var("TARGET", "x86_64-pc-windows-gnu");
-        assert_eq!(env::var("TARGET"), Ok("x86_64-pc-windows-gnu".to_string()));
+        env::set_var("TARGET", "aarch64-pc-windows-gnu");
+        assert_eq!(env::var("TARGET"), Ok("aarch64-pc-windows-gnu".to_string()));
         assert!(match ::probe_package("foo") {
-            Err(Error::NotMSVC) => true,
+            Err(Error::UnsupportedArchitecture) => true,
             _ => false,
         });
         env::remove_var("TARGET");
@@ -1640,6 +1640,8 @@ mod tests {
         for target in &[
             "x86_64-apple-darwin",
             "i686-pc-windows-msvc",
+            // TODO: add test data for platforms
+            // "x86_64-pc-windows-gnu",
             //      "x86_64-pc-windows-msvc",
             //    "x86_64-unknown-linux-gnu",
         ] {

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -12,7 +12,8 @@ extras=["zmq-sys"]
 # versions do not build
 curl = "*"
 libz-sys = "*"
-openssl-sys = "*"
+# TODO: roll back to upstream once vcpkg issue fixed
+openssl-sys = { git = "https://github.com/micolous/libz-sys", branch = "vcpkg" }
 zmq-sys = { git = "https://github.com/mcgoo/rust-zmq", branch = "vcpkg", optional=true }
 
 # always test against the vcpkg crate in this repo

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -11,9 +11,9 @@ extras=["zmq-sys"]
 # the purpose of this project is to fail in CI if the latest
 # versions do not build
 curl = "*"
-libz-sys = "*"
 # TODO: roll back to upstream once vcpkg issue fixed
-openssl-sys = { git = "https://github.com/micolous/libz-sys", branch = "vcpkg" }
+libz-sys = { git = "https://github.com/micolous/libz-sys", branch = "vcpkg" }
+openssl-sys = "*"
 zmq-sys = { git = "https://github.com/mcgoo/rust-zmq", branch = "vcpkg", optional=true }
 
 # always test against the vcpkg crate in this repo


### PR DESCRIPTION
Fixes #48

Work in progress, currently blocked on:

* [ ] Adding `link_lib_name_is_correct` tests for mingw. How do I generate new targets in `test-data/normalized`?
* [ ] Merging https://github.com/rust-lang/libz-sys/pull/136 (as they mask out vcpkg support on non-msvc)
* [ ] Figuring out any remaining test failures (for static target); `openssl-sys` probably has the same issue
