### PR TITLE
Remove explicit linkage include in tests to fix the ci test.

### DIFF
--- a/tests/harfbuzz/build.rs
+++ b/tests/harfbuzz/build.rs
@@ -8,7 +8,6 @@ fn main() {
     // libraries in. This only matters on Linux at present. (vcpkg itself
     // does fine, but vcpkg-rs needs to work out how to get the link order
     // from the it.)
-    println!("cargo:rustc-link-lib=brotlicommon-static");
 
     let mut build = cc::Build::new();
     build.file("src/test.c");

--- a/tests/harfbuzz/build.rs
+++ b/tests/harfbuzz/build.rs
@@ -4,11 +4,6 @@ extern crate vcpkg;
 fn main() {
     let libs = vcpkg::Config::new().find_package("harfbuzz").unwrap();
 
-    // vcpkg-rs is not capable of working out the correct order to link
-    // libraries in. This only matters on Linux at present. (vcpkg itself
-    // does fine, but vcpkg-rs needs to work out how to get the link order
-    // from the it.)
-
     let mut build = cc::Build::new();
     build.file("src/test.c");
     for inc in libs.include_paths {


### PR DESCRIPTION
I guess brotli has already been a static library so we don't need that.

Tested on both macOS and Windows. I'm wondering why this line was added.