### PR TITLE
Add code to expose the selected version of a requested package

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -948,14 +948,6 @@ impl Config {
         // if no overrides have been selected, then the Vcpkg port name
         // is the the .lib name and the .dll name
         if self.required_libs.is_empty() {
-            // if ports.get(&port_name.to_owned()).is_none() {
-            //     return Err(Error::LibNotFound(format!(
-            //         "package {} is not installed for vcpkg triplet {}",
-            //         port_name.to_owned(),
-            //         vcpkg_target.target_triplet.triplet
-            //     )));
-            // }
-
             // the complete set of ports required
             let mut required_ports: BTreeMap<String, Port> = BTreeMap::new();
             // working of ports that we need to include

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1347,7 +1347,7 @@ impl Library {
             found_names: Vec::new(),
             ports: Vec::new(),
             vcpkg_triplet: vcpkg_triplet.to_string(),
-            version,
+            version: version,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ pub struct Config {
 }
 
 /// Details of a package that was found
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Library {
     /// Paths for the linker to search for static or import libraries
     pub link_paths: Vec<PathBuf>,
@@ -187,6 +187,9 @@ pub struct Library {
 
     /// the vcpkg triplet that has been selected
     pub vcpkg_triplet: String,
+
+    /// The library version that has been selected
+    pub version: String,
 }
 
 #[derive(Clone)]
@@ -619,6 +622,7 @@ struct Port {
 
     // ports that this port depends on
     deps: Vec<String>,
+    version: String,
 }
 
 fn load_port_manifest(
@@ -816,6 +820,7 @@ fn load_ports(target: &VcpkgTarget) -> Result<BTreeMap<String, Port>, Error> {
                             dlls: lib_info.0,
                             libs: lib_info.1,
                             deps: deps,
+                            version: version.clone(),
                         };
 
                         ports.insert(name.to_string(), port);
@@ -931,18 +936,25 @@ impl Config {
         let vcpkg_target = try!(find_vcpkg_target(&self, &msvc_target));
         let mut required_port_order = Vec::new();
 
+        let ports = try!(load_ports(&vcpkg_target));
+        let version = match ports.get(&port_name.to_owned()) {
+            Some(port) => port.version.clone(),
+            None => return Err(Error::LibNotFound(format!(
+                "package {} is not installed for vcpkg triplet {}",
+                port_name.to_owned(),
+                vcpkg_target.target_triplet.triplet,
+            ))),
+        };
         // if no overrides have been selected, then the Vcpkg port name
         // is the the .lib name and the .dll name
         if self.required_libs.is_empty() {
-            let ports = try!(load_ports(&vcpkg_target));
-
-            if ports.get(&port_name.to_owned()).is_none() {
-                return Err(Error::LibNotFound(format!(
-                    "package {} is not installed for vcpkg triplet {}",
-                    port_name.to_owned(),
-                    vcpkg_target.target_triplet.triplet
-                )));
-            }
+            // if ports.get(&port_name.to_owned()).is_none() {
+            //     return Err(Error::LibNotFound(format!(
+            //         "package {} is not installed for vcpkg triplet {}",
+            //         port_name.to_owned(),
+            //         vcpkg_target.target_triplet.triplet
+            //     )));
+            // }
 
             // the complete set of ports required
             let mut required_ports: BTreeMap<String, Port> = BTreeMap::new();
@@ -1005,6 +1017,7 @@ impl Config {
                 }
             }
         }
+
         // require explicit opt-in before using dynamically linked
         // variants, otherwise cargo install of various things will
         // stop working if Vcpkg is installed.
@@ -1015,6 +1028,7 @@ impl Config {
         let mut lib = Library::new(
             vcpkg_target.target_triplet.is_static,
             &vcpkg_target.target_triplet.triplet,
+            version,
         );
 
         if self.emit_includes {
@@ -1156,9 +1170,20 @@ impl Config {
             return Err(Error::RequiredEnvMissing("VCPKGRS_DYNAMIC".to_owned()));
         }
 
+        let ports = try!(load_ports(&vcpkg_target));
+        let version = match ports.get(&port_name.to_owned()) {
+            Some(port) => port.version.clone(),
+            None => return Err(Error::LibNotFound(format!(
+                "package {} is not installed for vcpkg triplet {}",
+                port_name.to_owned(),
+                vcpkg_target.target_triplet.triplet,
+            ))),
+        };
+
         let mut lib = Library::new(
             vcpkg_target.target_triplet.is_static,
             &vcpkg_target.target_triplet.triplet,
+            version,
         );
 
         if self.emit_includes {
@@ -1318,7 +1343,7 @@ fn remove_item(cont: &mut Vec<String>, item: &String) -> Option<String> {
 }
 
 impl Library {
-    fn new(is_static: bool, vcpkg_triplet: &str) -> Library {
+    fn new(is_static: bool, vcpkg_triplet: &str, version: String) -> Library {
         Library {
             link_paths: Vec::new(),
             dll_paths: Vec::new(),
@@ -1330,6 +1355,7 @@ impl Library {
             found_names: Vec::new(),
             ports: Vec::new(),
             vcpkg_triplet: vcpkg_triplet.to_string(),
+            version,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,9 @@ pub struct Config {
 /// Details of a package that was found
 #[derive(Clone, Debug)]
 pub struct Library {
+    /// Ensure this struct can't be matched exhaustively/constructed from external code
+    __non_exhaustive: (),
+
     /// Paths for the linker to search for static or import libraries
     pub link_paths: Vec<PathBuf>,
 
@@ -1337,6 +1340,7 @@ fn remove_item(cont: &mut Vec<String>, item: &String) -> Option<String> {
 impl Library {
     fn new(is_static: bool, vcpkg_triplet: &str, version: String) -> Library {
         Library {
+            _non_exhaustive: (),
             link_paths: Vec::new(),
             dll_paths: Vec::new(),
             include_paths: Vec::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1340,7 +1340,7 @@ fn remove_item(cont: &mut Vec<String>, item: &String) -> Option<String> {
 impl Library {
     fn new(is_static: bool, vcpkg_triplet: &str, version: String) -> Library {
         Library {
-            _non_exhaustive: (),
+            __non_exhaustive: (),
             link_paths: Vec::new(),
             dll_paths: Vec::new(),
             include_paths: Vec::new(),


### PR DESCRIPTION
Makes it so the version of the port/package requested is added to the library struct returned, so consumers can do things based on what version they have. Also a drive-by add of `Clone` to `Library`, which is useful for the downstream I'm making this change for (https://github.com/tectonic-typesetting/tectonic/pull/1138).

This is a breaking change due to `Library` not being marked `#[non_exhaustive]` and having all public fields.