### PR TITLE
Support new tier 3 *-win7-windows-msvc targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1382,7 +1382,7 @@ fn detect_target_triplet() -> Result<TargetTriplet, Error> {
             lib_suffix: "a".into(),
             strip_lib_prefix: true,
         })
-    } else if !target.contains("-pc-windows-msvc") {
+    } else if !target.contains("-pc-windows-msvc") && !target.contains("-win7-windows-msvc") {
         Err(Error::NotMSVC)
     } else if target.starts_with("x86_64-") {
         if is_static {


### PR DESCRIPTION
Two new targets have been added with Windows 7 as their baseline: x86_64-win7-windows-msvc and i686-win7-windows-msvc. They are starting as Tier 3 targets, meaning that the Rust codebase has support for them but we don't build or test them automatically. Once these targets reach Tier 2 status, they will be available to use via rustup.

https://blog.rust-lang.org/2024/02/26/Windows-7.html