### PR TITLE
Add Android Targets (arm64, arm, x86, x64)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,19 +410,27 @@ fn find_vcpkg_target(cfg: &Config, target_triplet: &TargetTriplet) -> Result<Vcp
     let vcpkg_root = try!(find_vcpkg_root(&cfg));
     try!(validate_vcpkg_root(&vcpkg_root));
 
-    let mut base = cfg
+    let installed_root = cfg
         .vcpkg_installed_root
         .clone()
-        .or(env::var_os("VCPKG_INSTALLED_ROOT").map(PathBuf::from))
-        .unwrap_or(vcpkg_root.join("installed"));
+        .or(env::var_os("VCPKG_INSTALLED_ROOT").map(PathBuf::from));
 
-    let status_path = base.join("vcpkg");
+    let mut root = match installed_root { 
+        Some(path) => path,
+        None => {
+            let vcpkg_root = try!(find_vcpkg_root(&cfg));
+            try!(validate_vcpkg_root(&vcpkg_root));
+            vcpkg_root
+        }
+    };
 
-    base.push(&target_triplet.triplet);
+    let status_path = root.join("vcpkg");
 
-    let lib_path = base.join("lib");
-    let bin_path = base.join("bin");
-    let include_path = base.join("include");
+    root.push(&target_triplet.triplet);
+
+    let lib_path = root.join("lib");
+    let bin_path = root.join("bin");
+    let include_path = root.join("include");
     let packages_path = vcpkg_root.join("packages");
 
     Ok(VcpkgTarget {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1347,28 +1347,28 @@ fn detect_target_triplet() -> Result<TargetTriplet, Error> {
     let is_static = env::var("CARGO_CFG_TARGET_FEATURE")
         .unwrap_or(String::new()) // rustc 1.10
         .contains("crt-static");
-    if target == "x86_64-linux-android" {
+    if target == "x86_64-linux-android" || target == "x86_64-linux-androideabi"{
         Ok(TargetTriplet {
             triplet: "x64-android".into(),
             is_static: true,
             lib_suffix: "a".into(),
             strip_lib_prefix: true,
         })
-    } else if target == "aarch64-linux-android" {
+    } else if target == "aarch64-linux-android"|| target == "aarch64-linux-androideabi" {
         Ok(TargetTriplet {
             triplet: "arm64-android".into(),
             is_static: true,
             lib_suffix: "a".into(),
             strip_lib_prefix: true,
         })
-    } else if target == "armv7-linux-android" {
+    } else if target == "armv7-linux-android" || target == "armv7-linux-androideabi" {
         Ok(TargetTriplet {
             triplet: "arm-android".into(),
             is_static: true,
             lib_suffix: "a".into(),
             strip_lib_prefix: true,
         })
-    } else if target == "i686-linux-android" {
+    } else if target == "i686-linux-android" || target == "i686-linux-androideabi" {
         Ok(TargetTriplet {
             triplet: "x86-android".into(),
             is_static: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1347,7 +1347,35 @@ fn detect_target_triplet() -> Result<TargetTriplet, Error> {
     let is_static = env::var("CARGO_CFG_TARGET_FEATURE")
         .unwrap_or(String::new()) // rustc 1.10
         .contains("crt-static");
-    if target == "x86_64-apple-darwin" {
+    if target == "x86_64-linux-android" {
+        Ok(TargetTriplet {
+            triplet: "x64-android".into(),
+            is_static: true,
+            lib_suffix: "a".into(),
+            strip_lib_prefix: true,
+        })
+    } else if target == "aarch64-linux-android" {
+        Ok(TargetTriplet {
+            triplet: "arm64-android".into(),
+            is_static: true,
+            lib_suffix: "a".into(),
+            strip_lib_prefix: true,
+        })
+    } else if target == "armv7-linux-android" {
+        Ok(TargetTriplet {
+            triplet: "arm-android".into(),
+            is_static: true,
+            lib_suffix: "a".into(),
+            strip_lib_prefix: true,
+        })
+    } else if target == "i686-linux-android" {
+        Ok(TargetTriplet {
+            triplet: "x86-android".into(),
+            is_static: true,
+            lib_suffix: "a".into(),
+            strip_lib_prefix: true,
+        })
+    } else if target == "x86_64-apple-darwin" {
         Ok(TargetTriplet {
             triplet: "x64-osx".into(),
             is_static: true,


### PR DESCRIPTION
There are 4 Android Targets that vcpkg and rust both support.
vcpkg android targets all contain static .a libraries